### PR TITLE
Add power that Perfect Path was replaced by to Doomseer

### DIFF
--- a/data/mods/MindOverMatter/professions.json
+++ b/data/mods/MindOverMatter/professions.json
@@ -47,6 +47,7 @@
     "traits": [ "CLAIRSENTIENT", "CLAIR_SENSES", "SCHIZOPHRENIC" ],
     "spells": [
       { "id": "clair_night_vision", "level": 4 },
+      { "id": "clair_danger_sense", "level": 3 },
       { "id": "clair_spot_weakness", "level": 3 },
       { "id": "clair_voyance", "level": 2 }
     ],


### PR DESCRIPTION
Perfect Path was an old power I obsoleted--this just adds the power that it replaced to the Clairsentient scenario.